### PR TITLE
bug: exit the program if required environment variables are not set

### DIFF
--- a/ciapp/src/main/java/com/group7/ciapp/App.java
+++ b/ciapp/src/main/java/com/group7/ciapp/App.java
@@ -15,6 +15,13 @@ public class App {
      * @throws Exception
      */
     public static void main(String[] args) throws Exception {
+        // check that required environment variables are set
+        // PRIVATE_KEY_PATH and APP_ID
+        if (System.getenv("PRIVATE_KEY_PATH") == null || System.getenv("APP_ID") == null) {
+            System.out.println("Please set the environment variables PRIVATE_KEY_PATH and APP_ID");
+            System.exit(1);
+        }
+
         Server server = new Server(8080);
         server.setHandler(new WebServer());
         server.start();


### PR DESCRIPTION
exit the program in App.java before webserver starts if the env variables are not set upon runtime

fixes #54