### PR TITLE
bug: remove premature Git.shutdown() and move it to shutdown hook

### DIFF
--- a/ciapp/src/main/java/com/group7/ciapp/Project.java
+++ b/ciapp/src/main/java/com/group7/ciapp/Project.java
@@ -45,9 +45,7 @@ public class Project {
             this.git = Git.cloneRepository().setURI(url).setDirectory(new File(path)).call();
             // checkout specific commit
             this.git.checkout().setName(commitHash).call();
-            this.git.close();
             return path;
-
         } catch (Exception e) {
             System.out.println("Error cloning repository");
             // print exception code
@@ -62,10 +60,12 @@ public class Project {
      * @param path (String) The path to the cloned repository.
      */
     public void deleteRepo(String path) {
-        // Delete the cloned repository efter running tests
-        this.git.close();
-        this.git = null;
-        Git.shutdown();
+        // Delete the cloned repository after running tests
+        if (this.git != null) {
+            this.git.close();
+            this.git = null;
+        }
+
         File dir = new File(path);
         // TODO: Try this while testing dir.mkdirs();
         // Ensure the directory does not exists

--- a/ciapp/src/main/java/com/group7/ciapp/WebServer.java
+++ b/ciapp/src/main/java/com/group7/ciapp/WebServer.java
@@ -9,6 +9,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jgit.api.Git;
 import org.json.JSONObject;
 
 /**
@@ -20,9 +21,17 @@ public class WebServer extends AbstractHandler {
     private static ConfigReader configReader;
 
     /**
-     * Set configReader if null
+     * Add a shutdown hook to handle cleanup when server is stopped
+     * Set configReader if null, and load repositories
      */
     public WebServer() {
+        // add shutdown hook to handle cleanup when server is stopped
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.println("Shutdown hook running...");
+            Git.shutdown();
+            System.out.println("JGit Shutdown complete");
+        }));
+
         if (configReader == null) {
             configReader = new ConfigReader();
             configReader.loadRepositories();


### PR DESCRIPTION
Git.shutdown() was called after each run, which caused the entire JGit library to stop working after first run completed. This was not intended, and therefore a bug. This commit moves the Git.shutdown() to occur in hook upon program exit.

fixes #56