### PR TITLE
fix: remove unnecessary new instance of project in testCloneRepo_false

### DIFF
--- a/ciapp/src/test/java/com/group7/ciapp/ProjectTest.java
+++ b/ciapp/src/test/java/com/group7/ciapp/ProjectTest.java
@@ -34,15 +34,14 @@ public class ProjectTest {
     }
 
     /**
-     * Clone the repo and compare it with an non-existing path. The original path should not be
-     * null since it is a valid path. Path2 should not exist.
+     * Clone the repo and compare it with an non-existing path. The original path
+     * should not be null since it is a valid path. Path2 should not exist.
      */
     @Test
     void testCloneRepo_false() {
-        Project project2 = new Project(ProjectTest.testUrl, ProjectTest.testCommitHash, 2L);
-        String path = project2.cloneRepo();
+        String path = project.cloneRepo();
         String path2 = path.substring(0, path.length() - 1);
-        path2 = path2 + "1";
+        path2 = path2 + "2";
 
         File dir = new File(path2);
         boolean pathExists = dir.exists();


### PR DESCRIPTION
Remove new instance "project" in testCloneRepo since it is unnecessary if we change the checkId of the variable we create called path2. 

closes #60