### PR TITLE
fix: read BASE_URL from env file in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,4 @@ services:
       - PRIVATE_KEY_PATH=/usr/app/private-key.pem
       - DATABASE_PATH=/usr/app/database.db
       - APP_ID=${APP_ID} # read from .env file
+      - BASE_URL=${BASE_URL} # read from .env file


### PR DESCRIPTION
read BASE_URL as env variable from .env and expose it in docker container using docker-compose

fixes #80